### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ Install Grunt dependencies:
 ````bash
 npm install
 ````
+Note: If your install gets stuck, try this method:
+````bash
+npm install -g npm@6
+````
+
 Build Grunt project:
 ````bash
 grunt build


### PR DESCRIPTION
Addition of note to use npm version 6 to install grunt dependencies without any errors.

[The Solution on Stackoverflow](https://stackoverflow.com/questions/66893199/hanging-stuck-reifyprettier-timing-reifynodenode-modules-nrwl-workspace-comp)