### PR TITLE
aria label moved to link and icon hidden

### DIFF
--- a/post.hbs
+++ b/post.hbs
@@ -142,30 +142,13 @@
         {{! Links to Previous/Next posts }}
         <aside class="post-nav">
 
-          {{! If there's a next post, display it using the same markup included from - partials/post-card.hbs }}
-          {{#next_post}}
-            <a class="post-nav-next" href="{{url}}">
+          {{! If there's a previous post, display it using the same markup included from - partials/post-card.hbs }}
+          {{#prev_post}}
+            <a class="post-nav-prev" href="{{url}}" aria-label="{{t 'Previous post'}}">
               <section class="post-nav-teaser">
                 <i
                   class="icon icon-arrow-left"
-                  aria-label="{{t 'Next post'}}"
-                ></i>
-                <h2 class="post-nav-title">{{title}}</h2>
-                <p class="post-nav-excerpt">{{excerpt words="12"}}&hellip;</p>
-                <p class="post-nav-meta"><time
-                    datetime="{{date format="DD-MM-YYYY"}}"
-                  >{{date format="DD MMM YYYY"}}</time></p>
-              </section>
-            </a>
-          {{/next_post}}
-
-          {{! If there's a previous post, display it using the same markup included from - partials/post-card.hbs }}
-          {{#prev_post}}
-            <a class="post-nav-prev" href="{{url}}">
-              <section class="post-nav-teaser">
-                <i
-                  class="icon icon-arrow-right"
-                  aria-label="{{t 'Previous post'}}"
+                  aria-hidden="true"
                 ></i>
                 <h2 class="post-nav-title">{{title}}</h2>
                 <p class="post-nav-excerpt">{{excerpt words="12"}}&hellip;</p>
@@ -175,6 +158,23 @@
               </section>
             </a>
           {{/prev_post}}
+
+          {{! If there's a next post, display it using the same markup included from - partials/post-card.hbs }}
+          {{#next_post}}
+            <a class="post-nav-next" href="{{url}}" aria-label="{{t 'Next post'}}">
+              <section class="post-nav-teaser">
+                <i
+                  class="icon icon-arrow-right"
+                  aria-hidden="true"
+                ></i>
+                <h2 class="post-nav-title">{{title}}</h2>
+                <p class="post-nav-excerpt">{{excerpt words="12"}}&hellip;</p>
+                <p class="post-nav-meta"><time
+                    datetime="{{date format="DD-MM-YYYY"}}"
+                  >{{date format="DD MMM YYYY"}}</time></p>
+              </section>
+            </a>
+          {{/next_post}}
           <div class="clear"></div>
         </aside>
 


### PR DESCRIPTION
This is my suggestion for this accessibility issue, here's what I did:
- moved aria-label from the icon to the actual link
- added aria-hidden to the icon itself (it's decorative now that we have an aria-label on the link)
- switched the #prev_post and #next_post code blocks and ensured the icons were facing the respective direction

Warning: 
- I tried to set up the project, but didn't get it to run, so this was blindly coded, please check out the branch (or copy & paste the code) to try it out before merging. I'll admit that's poor practice, but making the changes was quicker than trying to get the setup to work, so just crossing my fingers here. If it doesn't work, feel free to take the code as inspiration (or ignore it completely) and then delete the PR, totally up to you. 

Love that you're taking accessibility into consideration :) 